### PR TITLE
Add Warp terminal to uses page

### DIFF
--- a/src/icons/warp.svg
+++ b/src/icons/warp.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path fill="currentColor" d="M2 4l2 16h3l3-8l3 8h3l2-16h-3l-1 10l-4-10l-4 10l-1-10H2Z"/>
+</svg>

--- a/src/pages/uses.astro
+++ b/src/pages/uses.astro
@@ -254,6 +254,26 @@ import Page from '../layouts/page.astro'
                     </a>
                 </div>
             </div>
+
+            <div class="my-2 mb-4 flex">
+                <div class="grow pr-2">
+                    <h3>Warp</h3>
+                    <div class="explanation">
+                        Modern terminal with AI features and a focus on productivity.
+                    </div>
+                </div>
+                <div class="link grow-0">
+                    <a
+                        href="https://www.warp.dev/"
+                        title="Warp Website"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                        class="text-blue-500 underline hover:text-blue-400 hover:no-underline"
+                    >
+                        <Icon name="warp" class="w-6" />
+                    </a>
+                </div>
+            </div>
         </section>
         <section class="my-2">
             <Title title="Productivity" subtitle="Tools" />


### PR DESCRIPTION
## Summary
- add an icon for Warp
- mention Warp terminal on the Uses page

## Testing
- `git status --short`